### PR TITLE
[#30] modify CommentMapper.xml

### DIFF
--- a/src/main/java/mygroup/boardservice/board/adapter/in/web/CommentApiController.java
+++ b/src/main/java/mygroup/boardservice/board/adapter/in/web/CommentApiController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import mygroup.boardservice.board.adapter.in.web.form.CommentForm;
 import mygroup.boardservice.board.application.port.in.comment.*;
 import mygroup.boardservice.board.domain.Comment;
+import mygroup.boardservice.board.domain.PostType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,19 +24,19 @@ public class CommentApiController {
 
     @GetMapping("/vipposts/{pid}/comments/{cid}")
     public ResponseEntity<Comment> readOne(@PathVariable Long cid){
-        Comment comment = getSpecificCommentUseCase.getComment(cid);
+        Comment comment = getSpecificCommentUseCase.getComment(cid, PostType.VIP);
         return new ResponseEntity<>(comment, HttpStatus.OK);
     }
 
     @GetMapping("/vipposts/{pid}/comments")
     public ResponseEntity<List<Comment>> readAll(@PathVariable Long pid){
-        List<Comment> comments = getAllCommentUseCase.getComments(pid);
+        List<Comment> comments = getAllCommentUseCase.getComments(pid, PostType.VIP);
         return new ResponseEntity<>(comments, HttpStatus.OK);
     }
 
     @PostMapping("/vipposts/{pid}/comments")
     public ResponseEntity save(@PathVariable Long pid, @RequestBody CommentForm.Request commentForm){
-        Long cid = saveCommentUseCase.saveComment(commentForm);
+        Long cid = saveCommentUseCase.saveComment(commentForm, PostType.VIP);
         return ResponseEntity.ok(cid);
     }
 

--- a/src/main/java/mygroup/boardservice/board/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/src/main/java/mygroup/boardservice/board/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -6,6 +6,7 @@ import mygroup.boardservice.board.application.port.out.comment.*;
 import mygroup.boardservice.board.application.port.out.comment.dto.CommentSaveDto;
 import mygroup.boardservice.board.application.port.out.comment.dto.CommentUpdateDto;
 import mygroup.boardservice.board.domain.Comment;
+import mygroup.boardservice.board.domain.PostType;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -19,27 +20,27 @@ public class CommentPersistenceAdapter implements DeleteCommentPort, GetAllComme
 
 
     @Override
-    public Comment getComment(Long commentId) {
-        return commentRepository.findById(commentId);
+    public Comment getComment(Long commentId, PostType postType) {
+        return commentRepository.findById(commentId, postType);
     }
 
     @Override
-    public List<Comment> getComments(Long postId) {
-        return commentRepository.findAll(postId);
+    public List<Comment> getComments(Long postId, PostType postType) {
+        return commentRepository.findAll(postId, postType);
     }
 
     @Override
-    public Long saveComment(CommentSaveDto commentSaveDto) {
-        return commentRepository.save(commentSaveDto);
+    public Long saveComment(CommentSaveDto commentSaveDto, PostType postType) {
+        return commentRepository.save(commentSaveDto, postType);
     }
 
     @Override
-    public void updateComment(CommentUpdateDto commentUpdateDto) {
-        commentRepository.update(commentUpdateDto);
+    public void updateComment(CommentUpdateDto commentUpdateDto, PostType postType) {
+        commentRepository.update(commentUpdateDto, postType);
     }
 
     @Override
-    public void deleteComment(Long commentId) {
-        commentRepository.delete(commentId);
+    public void deleteComment(Long commentId, PostType postType) {
+        commentRepository.delete(commentId, postType);
     }
 }

--- a/src/main/java/mygroup/boardservice/board/adapter/out/persistence/mapper/CommentMapper.java
+++ b/src/main/java/mygroup/boardservice/board/adapter/out/persistence/mapper/CommentMapper.java
@@ -3,11 +3,9 @@ package mygroup.boardservice.board.adapter.out.persistence.mapper;
 import mygroup.boardservice.board.application.port.out.comment.dto.CommentSaveDto;
 import mygroup.boardservice.board.application.port.out.comment.dto.CommentUpdateDto;
 import mygroup.boardservice.board.domain.Comment;
-import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
 
-@Mapper
 public interface CommentMapper {
     Comment findById(Long id);
     List<Comment> findAll(Long postId);

--- a/src/main/java/mygroup/boardservice/board/adapter/out/persistence/mapper/VipCommentMapper.java
+++ b/src/main/java/mygroup/boardservice/board/adapter/out/persistence/mapper/VipCommentMapper.java
@@ -1,0 +1,8 @@
+package mygroup.boardservice.board.adapter.out.persistence.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface VipCommentMapper extends CommentMapper {
+
+}

--- a/src/main/java/mygroup/boardservice/board/adapter/out/persistence/repository/CommentRepository.java
+++ b/src/main/java/mygroup/boardservice/board/adapter/out/persistence/repository/CommentRepository.java
@@ -2,32 +2,50 @@ package mygroup.boardservice.board.adapter.out.persistence.repository;
 
 import lombok.RequiredArgsConstructor;
 import mygroup.boardservice.board.adapter.out.persistence.mapper.CommentMapper;
+import mygroup.boardservice.board.adapter.out.persistence.mapper.VipCommentMapper;
 import mygroup.boardservice.board.application.port.out.comment.dto.CommentSaveDto;
 import mygroup.boardservice.board.application.port.out.comment.dto.CommentUpdateDto;
 import mygroup.boardservice.board.domain.Comment;
+import mygroup.boardservice.board.domain.PostType;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Repository
 public class CommentRepository {
-    private final CommentMapper commentMapper;
+    private final Map<String, CommentMapper> commentMapperMap;
 
-    public Comment findById(Long commentId){
+    public Comment findById(Long commentId, PostType postType){
+        CommentMapper commentMapper = getCommentMapper(postType);
         return commentMapper.findById(commentId);
     }
 
-    public List<Comment> findAll(Long postId){
+    public List<Comment> findAll(Long postId, PostType postType){
+        CommentMapper commentMapper = getCommentMapper(postType);
         return commentMapper.findAll(postId);
     }
 
-    public Long save(CommentSaveDto commentSaveDto){
+    public Long save(CommentSaveDto commentSaveDto, PostType postType){
+        CommentMapper commentMapper = getCommentMapper(postType);
         commentMapper.save(commentSaveDto);
         return commentSaveDto.getId();
     }
 
-    public void update(CommentUpdateDto commentUpdateDto){ commentMapper.update(commentUpdateDto); }
+    public void update(CommentUpdateDto commentUpdateDto, PostType postType){
+        CommentMapper commentMapper = getCommentMapper(postType);
+        commentMapper.update(commentUpdateDto);
+    }
 
-    public void delete(Long id){ commentMapper.delete(id); }
+    public void delete(Long id, PostType postType){
+        CommentMapper commentMapper = getCommentMapper(postType);
+        commentMapper.delete(id);
+    }
+
+    private CommentMapper getCommentMapper(PostType postType){
+        String mapperName = postType.toString().toLowerCase(Locale.ROOT) + "CommentMapper";
+        return commentMapperMap.get(mapperName);
+    }
 }

--- a/src/main/java/mygroup/boardservice/board/application/port/in/comment/DeleteCommentUseCase.java
+++ b/src/main/java/mygroup/boardservice/board/application/port/in/comment/DeleteCommentUseCase.java
@@ -1,5 +1,7 @@
 package mygroup.boardservice.board.application.port.in.comment;
 
+import mygroup.boardservice.board.domain.PostType;
+
 public interface DeleteCommentUseCase {
-    void deleteComment(Long commentId);
+    void deleteComment(Long commentId, PostType postType);
 }

--- a/src/main/java/mygroup/boardservice/board/application/port/in/comment/GetAllCommentUseCase.java
+++ b/src/main/java/mygroup/boardservice/board/application/port/in/comment/GetAllCommentUseCase.java
@@ -1,9 +1,10 @@
 package mygroup.boardservice.board.application.port.in.comment;
 
 import mygroup.boardservice.board.domain.Comment;
+import mygroup.boardservice.board.domain.PostType;
 
 import java.util.List;
 
 public interface GetAllCommentUseCase {
-    List<Comment> getComments(Long postId);
+    List<Comment> getComments(Long postId, PostType postType);
 }

--- a/src/main/java/mygroup/boardservice/board/application/port/in/comment/GetSpecificCommentUseCase.java
+++ b/src/main/java/mygroup/boardservice/board/application/port/in/comment/GetSpecificCommentUseCase.java
@@ -1,7 +1,8 @@
 package mygroup.boardservice.board.application.port.in.comment;
 
 import mygroup.boardservice.board.domain.Comment;
+import mygroup.boardservice.board.domain.PostType;
 
 public interface GetSpecificCommentUseCase {
-    Comment getComment(Long commentId);
+    Comment getComment(Long commentId, PostType postType);
 }

--- a/src/main/java/mygroup/boardservice/board/application/port/in/comment/SaveCommentUseCase.java
+++ b/src/main/java/mygroup/boardservice/board/application/port/in/comment/SaveCommentUseCase.java
@@ -1,8 +1,8 @@
 package mygroup.boardservice.board.application.port.in.comment;
 
 import mygroup.boardservice.board.adapter.in.web.form.CommentForm;
-import mygroup.boardservice.board.application.port.out.comment.dto.CommentSaveDto;
+import mygroup.boardservice.board.domain.PostType;
 
 public interface SaveCommentUseCase {
-    Long saveComment(CommentForm.Request commentForm);
+    Long saveComment(CommentForm.Request commentForm, PostType postType);
 }

--- a/src/main/java/mygroup/boardservice/board/application/port/in/comment/UpdateCommentUseCase.java
+++ b/src/main/java/mygroup/boardservice/board/application/port/in/comment/UpdateCommentUseCase.java
@@ -1,7 +1,8 @@
 package mygroup.boardservice.board.application.port.in.comment;
 
 import mygroup.boardservice.board.application.port.out.comment.dto.CommentUpdateDto;
+import mygroup.boardservice.board.domain.PostType;
 
 public interface UpdateCommentUseCase {
-    void updateComment(CommentUpdateDto commentUpdateDto);
+    void updateComment(CommentUpdateDto commentUpdateDto, PostType postType);
 }

--- a/src/main/java/mygroup/boardservice/board/application/port/out/comment/DeleteCommentPort.java
+++ b/src/main/java/mygroup/boardservice/board/application/port/out/comment/DeleteCommentPort.java
@@ -1,5 +1,7 @@
 package mygroup.boardservice.board.application.port.out.comment;
 
+import mygroup.boardservice.board.domain.PostType;
+
 public interface DeleteCommentPort {
-    void deleteComment(Long commentId);
+    void deleteComment(Long commentId, PostType postType);
 }

--- a/src/main/java/mygroup/boardservice/board/application/port/out/comment/GetAllCommentPort.java
+++ b/src/main/java/mygroup/boardservice/board/application/port/out/comment/GetAllCommentPort.java
@@ -1,9 +1,10 @@
 package mygroup.boardservice.board.application.port.out.comment;
 
 import mygroup.boardservice.board.domain.Comment;
+import mygroup.boardservice.board.domain.PostType;
 
 import java.util.List;
 
 public interface GetAllCommentPort {
-    List<Comment> getComments(Long postId);
+    List<Comment> getComments(Long postId, PostType postType);
 }

--- a/src/main/java/mygroup/boardservice/board/application/port/out/comment/GetSpecificCommentPort.java
+++ b/src/main/java/mygroup/boardservice/board/application/port/out/comment/GetSpecificCommentPort.java
@@ -1,7 +1,8 @@
 package mygroup.boardservice.board.application.port.out.comment;
 
 import mygroup.boardservice.board.domain.Comment;
+import mygroup.boardservice.board.domain.PostType;
 
 public interface GetSpecificCommentPort {
-    Comment getComment(Long commentId);
+    Comment getComment(Long commentId, PostType postType);
 }

--- a/src/main/java/mygroup/boardservice/board/application/port/out/comment/SaveCommentPort.java
+++ b/src/main/java/mygroup/boardservice/board/application/port/out/comment/SaveCommentPort.java
@@ -1,7 +1,8 @@
 package mygroup.boardservice.board.application.port.out.comment;
 
 import mygroup.boardservice.board.application.port.out.comment.dto.CommentSaveDto;
+import mygroup.boardservice.board.domain.PostType;
 
 public interface SaveCommentPort {
-    Long saveComment(CommentSaveDto commentSaveDto);
+    Long saveComment(CommentSaveDto commentSaveDto, PostType postType);
 }

--- a/src/main/java/mygroup/boardservice/board/application/port/out/comment/UpdateCommentPort.java
+++ b/src/main/java/mygroup/boardservice/board/application/port/out/comment/UpdateCommentPort.java
@@ -1,7 +1,8 @@
 package mygroup.boardservice.board.application.port.out.comment;
 
 import mygroup.boardservice.board.application.port.out.comment.dto.CommentUpdateDto;
+import mygroup.boardservice.board.domain.PostType;
 
 public interface UpdateCommentPort {
-    void updateComment(CommentUpdateDto commentUpdateDto);
+    void updateComment(CommentUpdateDto commentUpdateDto, PostType postType);
 }

--- a/src/main/java/mygroup/boardservice/board/application/service/CommentService.java
+++ b/src/main/java/mygroup/boardservice/board/application/service/CommentService.java
@@ -7,6 +7,7 @@ import mygroup.boardservice.board.application.port.out.comment.*;
 import mygroup.boardservice.board.application.port.out.comment.dto.CommentSaveDto;
 import mygroup.boardservice.board.application.port.out.comment.dto.CommentUpdateDto;
 import mygroup.boardservice.board.domain.Comment;
+import mygroup.boardservice.board.domain.PostType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,31 +25,31 @@ public class CommentService implements DeleteCommentUseCase, GetAllCommentUseCas
     private final UpdateCommentPort updateCommentPort;
 
     @Override
-    public Comment getComment(Long commentId) {
-        return getSpecificCommentPort.getComment(commentId);
+    public Comment getComment(Long commentId, PostType postType) {
+        return getSpecificCommentPort.getComment(commentId, postType);
     }
 
     @Override
-    public List<Comment> getComments(Long postId) {
-        return getAllCommentPort.getComments(postId);
+    public List<Comment> getComments(Long postId, PostType postType) {
+        return getAllCommentPort.getComments(postId, postType);
     }
 
     @Transactional
     @Override
-    public Long saveComment(CommentForm.Request commentForm) {
+    public Long saveComment(CommentForm.Request commentForm, PostType postType) {
         CommentSaveDto commentSaveDto = commentForm.toSaveEntity();
-        return saveCommentPort.saveComment(commentSaveDto);
+        return saveCommentPort.saveComment(commentSaveDto, postType);
     }
 
     @Transactional
     @Override
-    public void updateComment(CommentUpdateDto commentUpdateDto) {
-        updateCommentPort.updateComment(commentUpdateDto);
+    public void updateComment(CommentUpdateDto commentUpdateDto, PostType postType) {
+        updateCommentPort.updateComment(commentUpdateDto, postType);
     }
 
     @Transactional
     @Override
-    public void deleteComment(Long commentId) {
-        deleteCommentPort.deleteComment(commentId);
+    public void deleteComment(Long commentId, PostType postType) {
+        deleteCommentPort.deleteComment(commentId, postType);
     }
 }

--- a/src/main/java/mygroup/boardservice/board/domain/PostType.java
+++ b/src/main/java/mygroup/boardservice/board/domain/PostType.java
@@ -1,0 +1,5 @@
+package mygroup.boardservice.board.domain;
+
+public enum PostType {
+    VIP, COMMON
+}

--- a/src/main/resources/mapper/VipCommentMapper.xml
+++ b/src/main/resources/mapper/VipCommentMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="mygroup.boardservice.board.adapter.out.persistence.mapper.CommentMapper">
+<mapper namespace="mygroup.boardservice.board.adapter.out.persistence.mapper.VipCommentMapper">
     <resultMap id="CommentResultMap" type="Comment">
         <constructor>
             <idArg column="id" javaType="long"/>

--- a/src/test/java/mygroup/boardservice/board/adapter/out/persistence/repository/CommentRepositoryTest.java
+++ b/src/test/java/mygroup/boardservice/board/adapter/out/persistence/repository/CommentRepositoryTest.java
@@ -2,10 +2,11 @@ package mygroup.boardservice.board.adapter.out.persistence.repository;
 
 import lombok.extern.slf4j.Slf4j;
 import mygroup.boardservice.board.adapter.out.persistence.mapper.CommentMapper;
-import mygroup.boardservice.board.adapter.out.persistence.mapper.UserMapper;
+import mygroup.boardservice.board.adapter.out.persistence.mapper.VipCommentMapper;
 import mygroup.boardservice.board.application.port.out.comment.dto.CommentSaveDto;
 import mygroup.boardservice.board.application.port.out.comment.dto.CommentUpdateDto;
 import mygroup.boardservice.board.domain.Comment;
+import mygroup.boardservice.board.domain.PostType;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,15 +14,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.sql.Date;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.Locale;
+import java.util.Map;
 
 @SpringBootTest
 @Slf4j
 class CommentRepositoryTest {
 
     @Autowired
-    private CommentMapper commentMapper;
+    private VipCommentMapper commentMapper;
+
+    @Autowired
+    private Map<String, CommentMapper> commentMapperMap;
 
     @Test
     void findById() {
@@ -75,5 +79,12 @@ class CommentRepositoryTest {
         //then
         Assertions.assertThat(commentMapper.findById(commentSaveDto.getId())).isNull();
 
+    }
+
+    @Test
+    void getCommentMapper(){
+        String mapperName = PostType.VIP.toString().toLowerCase(Locale.ROOT) + "CommentMapper";
+        Assertions.assertThat(commentMapperMap.get("xx")).isNull();
+        Assertions.assertThat(commentMapperMap.get(mapperName)).isNotNull();
     }
 }


### PR DESCRIPTION
- 이전 30-fix 브랜치에서 Comment 테이블을 없애고 각 게시판 마다 댓글 테이블을 만들었다. (ex. vip_comment)
- 그래서 이번 브랜치에선 CommentMapper.xml을 지우고 각 테이블마다 매퍼 xml 파일을 만들었다. (VipCommentMapper.xml) 그리고 이 xml 매퍼 파일의 namespace를 알맞게 지정하였고 여기에 맞는 매퍼 인터페이스를 생성했다. (VipCommentMapper.java)
- PostType을 매개변수로 받도록 모든 Comment 관련 인바운드, 아웃바운드 포트를 수정했다. 그리고 이 포트를 직간접적으로 사용하는 클래스들도 모두 수정했다.
- CommentRepository에서 매개변수로 넘겨받은 PostType에 따라 적절한 CommentMapper를 사용하도록 수정했다.